### PR TITLE
[CI] Publish docker images to `ghcr.io`

### DIFF
--- a/.github/workflows/docker-publish-os.yml
+++ b/.github/workflows/docker-publish-os.yml
@@ -1,0 +1,224 @@
+name: Build and Publish Docker Images for a single OS
+
+on:
+  workflow_call:
+    inputs:
+      dockerfile:
+        type: string
+        description: 'Dockerfile to use'
+        required: true
+      docker-image-suffix:
+        type: string
+        description: 'Docker image suffix'
+        required: true
+      cache-name:
+        type: string
+        description: 'Cache name'
+        required: true
+      platforms:
+        type: string
+        description: 'Platforms to build for'
+        required: true
+
+# inspired by https://github.com/TECH7Fox/asterisk-hass-addons/blob/main/.github/workflows/ci.yaml
+
+permissions:
+  packages: write
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get lowercase GitHub username
+        id: repository_owner
+        uses: ASzc/change-string-case-action@v6
+        with:
+          string: ${{ github.repository_owner }}
+      - name: Docker images
+        id: docker-images
+        run: |
+          echo 'image=ghcr.io/${{ steps.repository_owner.outputs.lowercase }}/speedtest-rust' >> "${GITHUB_OUTPUT}"
+          # Only enable push on push events or pull requests coming from the same repository, except from dependabot
+          echo 'push=${{ github.event_name == 'push' || github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}' >> "${GITHUB_OUTPUT}"
+      - name: Docker meta
+        id: docker-meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ steps.docker-images.outputs.image }}
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            # Tag with branch name
+            type=ref,event=branch,suffix=${{ inputs.docker-image-suffix }}
+            # Tag with PR number
+            type=ref,event=pr,suffix=${{ inputs.docker-image-suffix }}
+            # Tag with git tag on release
+            type=ref,event=tag,suffix=${{ inputs.docker-image-suffix }}
+            # Custom "release" tag for release events
+            type=raw,value=release,enable=${{ github.event_name == 'release' }},suffix=${{ inputs.docker-image-suffix }}
+            # Tag as latest only for Debian in release events
+            type=raw,value=latest,enable=${{ github.event_name == 'release' && inputs.cache-name == 'debian' }}
+    outputs:
+      image: ${{ steps.docker-images.outputs.image }}
+      push: ${{ steps.docker-images.outputs.push }}
+      meta-version: ${{ steps.docker-meta.outputs.version }}
+      meta-labels: ${{ steps.docker-meta.outputs.labels }}
+      meta-json: ${{ steps.docker-meta.outputs.json }}
+  build:
+    needs:
+      - prepare
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: ${{ fromJson(inputs.platforms) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Needed to calculate branch for tag
+          fetch-depth: 0
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GitHub Container Registry
+        if: needs.prepare.outputs.push == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Cache
+        uses: actions/cache@v4
+        id: cache
+        with:
+          path: |
+            ${{ inputs.cache-name }}-${{ matrix.platform }}-var-cache-os-package-manager-cache
+            ${{ inputs.cache-name }}-${{ matrix.platform }}-var-cache-os-package-manager-lib
+            ${{ inputs.cache-name }}-${{ matrix.platform }}-cargo-registry
+            ${{ inputs.cache-name }}-${{ matrix.platform }}-target
+          # Currently the cache is invalidated when the respective Dockerfile changes
+          # If the mount cache should persist across dockerfile and instead depend on some other file the input to the hashFiles function should be changed
+          key: cache-${{ hashFiles(inputs.dockerfile) }}-${{ inputs.cache-name }}-${{ matrix.platform }}
+
+      - name: Inject cache into docker
+        uses: reproducible-containers/buildkit-cache-dance@v3.1.0
+        with:
+          cache-map: |
+            {
+              "${{ inputs.cache-name }}-${{ matrix.platform }}-var-cache-os-package-manager-cache": {
+                "target": "/var/cache/apt",
+                "id": "speedtest-rust-debian-apt-cache"
+              },
+              "${{ inputs.cache-name }}-${{ matrix.platform }}-var-cache-os-package-manager-lib": {
+                "target": "/var/lib/apt",
+                "id": "speedtest-rust-debian-apt-lib"
+              },
+              "${{ inputs.cache-name }}-${{ matrix.platform }}-var-cache-os-package-manager-cache": {
+                "target": "/var/cache/apk",
+                "id": "speedtest-rust-alpine-apk-cache"
+              },
+              "${{ inputs.cache-name }}-${{ matrix.platform }}-cargo-registry": {
+                "target": "/usr/local/cargo/registry",
+                "id": "speedtest-rust-${{ inputs.cache-name }}-cargo-registry"
+              },
+              "${{ inputs.cache-name }}-${{ matrix.platform }}-target": {
+                "target": "/usr/local/src/target",
+                "id": "speedtest-rust-${{ inputs.cache-name }}-target"
+              }
+            }
+          skip-extraction: ${{ steps.cache.outputs.cache-hit }}
+      - name: Set vars
+        id: vars
+        run: |
+          echo "artifact-name=digest-$(echo '${{ inputs.cache-name }}-${{ matrix.platform }}' | tr / -)" >> "${GITHUB_OUTPUT}"
+
+          # Set the cache-to output
+          echo 'cache-to=type=gha,scope=${{ github.ref_name }}-${{ inputs.cache-name }}-${{ matrix.platform }}' >> "${GITHUB_OUTPUT}"
+
+          # Set the cache-from output
+          if [[ '${{ github.event_name }}' == 'push' ]]; then
+            if [[ '${{ github.ref }}' == 'refs/tags/v'* ]]; then
+              # Use cache from the branch when building a tag
+              branch="$(git branch -r --contains '${{ github.ref }}')"
+              branch="${branch##*/}"
+              echo "cache-from=type=gha,scope=${branch}-${{ inputs.cache-name }}-${{ matrix.platform }}" >> "${GITHUB_OUTPUT}"
+            else
+              # Use cache from the same branch when not building a tag
+              echo 'cache-from=type=gha,scope=${{ github.ref_name }}-${{ inputs.cache-name }}-${{ matrix.platform }}' >> "${GITHUB_OUTPUT}"
+            fi
+          else
+            # Use cache from target branch too when building a pull request
+
+            # In this case, it has to be a multiline string
+            # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
+            EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+
+            echo "cache-from<<${EOF}" >> "${GITHUB_OUTPUT}"
+
+            printf '%s\n' \
+              "type=gha,scope=${{ github.ref_name }}-${{ inputs.cache-name }}-${{ matrix.platform }}" \
+              "type=gha,scope=${{ github.base_ref }}-${{ inputs.cache-name }}-${{ matrix.platform }}" \
+              >> "${GITHUB_OUTPUT}"
+
+            echo "${EOF}" >> "${GITHUB_OUTPUT}"
+          fi
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{inputs.dockerfile }}
+          platforms: ${{ matrix.platform }}
+          labels: ${{ needs.prepare.outputs.meta-labels }}
+          outputs: |
+            type=image,name=${{ needs.prepare.outputs.image }},push-by-digest=true,name-canonical=true,push=${{ needs.prepare.outputs.push }}
+          cache-from: |
+            ${{ steps.vars.outputs.cache-from }}
+          cache-to: |
+            ${{ steps.vars.outputs.cache-to }}
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest='${{ steps.build.outputs.digest }}'
+          touch "/tmp/digests/${digest#sha256:}"
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.vars.outputs.artifact-name }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  push:
+    needs:
+      - prepare
+      - build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          pattern: digest-${{ inputs.cache-name }}*
+          merge-multiple: true
+          path: /tmp/digests
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GitHub Container Registry
+        if: needs.prepare.outputs.push == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create manifest list and push
+        if: needs.prepare.outputs.push == 'true'
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -r '"-t " + (.tags | join(" -t "))' <<< '${{ needs.prepare.outputs.meta-json }}') \
+            $(printf '${{ needs.prepare.outputs.image }}@sha256:%s ' *)
+      - name: Inspect image
+        if: needs.prepare.outputs.push == 'true'
+        run: |
+          docker buildx imagetools inspect '${{ needs.prepare.outputs.image }}:${{ needs.prepare.outputs.meta-version }}'

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,39 @@
+name: Build and Publish Docker Images for all OSes
+
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+  push:
+    tags:
+      - v[0-9]+.* # This will run on version tags on any branch
+    branches:
+      - feat/docker # This can be removed but is useful for testing images will be tagged feat-docker...
+      # Other branches can be added here
+  release:
+    types:
+      - published
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  packages: write
+
+jobs:
+  build_publish_debian:
+    uses: ./.github/workflows/docker-publish-os.yml
+    secrets: inherit
+    with:
+      dockerfile: Dockerfile
+      docker-image-suffix: ''
+      cache-name: debian
+      platforms: "['linux/amd64','linux/386','linux/arm/v7','linux/arm64']"
+  build_publish_alpine:
+    uses: ./.github/workflows/docker-publish-os.yml
+    secrets: inherit
+    with:
+      dockerfile: Dockerfile.alpine
+      docker-image-suffix: '-alpine'
+      cache-name: alpine
+      platforms: "['linux/amd64','linux/arm64']"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,30 @@
+# syntax=docker/dockerfile:1
 # Build
-FROM rust:1 as builder
+FROM rust:1 AS builder
 WORKDIR /usr/local/src
+
+# OS deps
+# https://github.com/reproducible-containers/buildkit-cache-dance
+ENV DEBIAN_FRONTEND=noninteractive
+RUN \
+	--mount=type=cache,id=speedtest-rust-debian-apt-cache,target=/var/cache/apt,sharing=locked \
+	--mount=type=cache,id=speedtest-rust-debian-apt-lib,target=/var/lib/apt,sharing=locked \
+	rm -f /etc/apt/apt.conf.d/docker-clean && \
+	echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' >/etc/apt/apt.conf.d/keep-cache && \
+	apt-get update && \
+	apt-get install -y mold clang
+
 COPY . .
-RUN cargo build --release
+RUN --mount=type=cache,id=speedtest-rust-debian-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
+	--mount=type=cache,id=speedtest-rust-debian-target,target=/usr/local/src/target,sharing=locked \
+	RUSTFLAGS="-C linker=clang -C link-arg=-fuse-ld=$(which mold)" \
+	cargo install --path . --target-dir target
 
 # Run
-FROM debian:12
+FROM debian:bullseye-slim
 WORKDIR /usr/local/bin
 COPY --from=builder \
-	/usr/local/src/target/release/librespeed-rs \
+	/usr/local/cargo/bin/librespeed-rs \
 	librespeed-rs
 COPY configs.toml configs.toml
 COPY assets assets

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,41 @@
+# syntax=docker/dockerfile:1
+# Build
+FROM rust:1-alpine3.20 AS builder
+WORKDIR /usr/local/src
+
+# OS deps
+RUN --mount=type=cache,id=speedtest-rust-alpine-apk,sharing=locked,target=/var/cache/apk \
+	set -eux; \
+	apk add build-base mold clang;
+
+# This seems to be an issue with libm
+# It should be reported to the libm crate after verifying that is really the cause of the compilation error
+RUN set -eux; \
+	SRC_PREFIX="/usr/bin/x86_64-alpine-linux-musl-"; \
+	TARGET_PREFIX="/usr/bin/x86_64-linux-musl-"; \
+	binaries="c++ cc g++ gcc gcc-13.2.1 gcc-ar gcc-nm gcc-ranlib"; \
+	for bin in $binaries; do \
+	if [ -e "${SRC_PREFIX}${bin}" ]; then \
+	ln -sf "${SRC_PREFIX}${bin}" "${TARGET_PREFIX}${bin}"; \
+	echo "Created symlink for ${bin}"; \
+	else \
+	echo "Source binary ${SRC_PREFIX}${bin} not found, skipping"; \
+	fi \
+	done;
+
+COPY . .
+RUN --mount=type=cache,id=speedtest-rust-alpine-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
+	--mount=type=cache,id=speedtest-rust-alpine-target,target=/usr/local/src/target,sharing=locked \
+	RUSTFLAGS="-C linker=clang -C link-arg=-fuse-ld=$(which mold)" \
+	cargo install --path . --target-dir target
+
+# Run
+FROM alpine:3.20
+WORKDIR /usr/local/bin
+COPY --from=builder \
+	/usr/local/cargo/bin/librespeed-rs \
+	librespeed-rs
+COPY configs.toml configs.toml
+COPY assets assets
+EXPOSE 8080
+CMD ["librespeed-rs"]


### PR DESCRIPTION
Microsoft provides free CI compute so why not use it to automatically build releases and push them to the `ghcr.io`?

I suggest updating the readme.
Adding a commented out `image:` line to the `docker-compose` files would be nice too.

I also took the `liberty` to use `cargo install` for a predictable binary destination.

There seem to be some issues with the build scripts of the libm create on alpine which should be further investigated. I just worked around them with symlinks.

I split it up into two commits to ease review.

Should you want a `:master` docker tag, you can just add to `feat/docker` under the triggers.
If you want me to provide updates/support down the line it would be nice if you kept the `feat/docker` trigger.

If you want any changes let me know.

I could also touch up the normal release ci with some cache if wanted.

PS: Sorry for any notification spam. I thought I was done way earlier but decided to take it to the next level.