### PR TITLE
Set std_listener to non-blocking mode

### DIFF
--- a/src/http/tcp_socket.rs
+++ b/src/http/tcp_socket.rs
@@ -56,6 +56,7 @@ impl TcpSocket {
         socket.set_reuse_address(true)?;
         socket.bind(&tcp_addr.sock_addr.into())?;
         socket.listen(128)?;
+        socket.set_nonblocking(true)?;
         let tcp_listener = TcpListener::from_std(socket.into())?;
         Ok(tcp_listener)
     }


### PR DESCRIPTION
According to the [docs](https://docs.rs/tokio/latest/tokio/net/struct.TcpListener.html#method.from_std), Tokio's `TcpListener::from_std` requires the underlying `std::net::TcpListener` to be in non-blocking mode. Otherwise `accept().await` will block the executor thread. This is especially problematic with a single-threaded runtime.