### PR TITLE
Add enable_time() when worker_threads="auto"

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -87,6 +87,7 @@ pub fn init_runtime () -> std::io::Result<Runtime> {
     if worker_threads.is_string() && worker_threads == "auto" {
         Builder::new_multi_thread()
             .thread_name("librespeed-rs")
+            .enable_time()
             .enable_io()
             .build()
     } else {


### PR DESCRIPTION
Since `tokio::time::sleep` is used in `accept()`, we need to add `enable_time()` in the runtime builder.

But I didn't get the idea why we chose to sleep here? In the current implementation, every time when `tcp_socket.accept()` is called, it will likely waste some time, return an `Err` and leave a trace message. If the listeners are many, it might harm the responsiveness. Maybe the better way is to spawn a separate task per listener to call `listener.accept()`, and see who comes first? Like using `futures:future:select_all`. Or even simpler, to only support the case with one single listener, like [speedtest-go](https://github.com/librespeed/speedtest-go/pull/35/files#diff-17bd1293d66c18344655b66a75ac56c5798e7407a1670834166b12ee3585ad2b) did. Correct me if I'm wrong. Thank you!