### PR TITLE
Use future::select_all for accept()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -690,6 +690,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -704,6 +719,23 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
@@ -734,10 +766,13 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -1136,6 +1171,7 @@ dependencies = [
  "chrono",
  "clap",
  "env_logger",
+ "futures",
  "handlebars",
  "imageproc",
  "include_dir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ webpki-roots = "0.26.8"
 rustls-pemfile = "2.2.0"
 socket2 = "0.5.8"
 listenfd = "1.0.2"
+futures = "0.3.31"
 #ip
 maxminddb = "0.25.0"
 #image processing


### PR DESCRIPTION
The goal of `accept()`  is to accept a connection from *any* available listener as soon as possible. In the previous implementation, `select!` waits on only the current listener and a timer. It forces the executor to wait 1ms if the accept() call on the current listener doesn't return within 1ms, and if no connection is immediately available on the current listener, there will be another minimum 1ms delay.
This pr tries to improve it by using `future::select_all` to wait on multiple listeners simultaneously and return the first one that completes.