### PR TITLE
Add alpine dockerfile

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,18 @@
+# Build
+FROM rust:alpine as builder
+ENV RUSTFLAGS="-C linker=gcc"
+WORKDIR /usr/local/src
+COPY . .
+RUN apk add --no-cache gcc musl-dev
+RUN cargo build --release
+
+# Run
+FROM scratch
+WORKDIR /usr/local/bin
+COPY --from=builder \
+	/usr/local/src/target/release/librespeed-rs \
+	librespeed-rs
+COPY configs.toml configs.toml
+COPY assets assets
+EXPOSE 8080
+CMD ["librespeed-rs"]


### PR DESCRIPTION
Uses alpine to build a statically-linked musl executable, then copies to scratch

Produces a much smaller image than the default bookworm-based dockerfile.
```
[cobalt@minerva speedtest-rust]$ docker images
REPOSITORY                   TAG            IMAGE ID       CREATED          SIZE
librespeed-rs-alpine         latest         62b68e4af0e0   10 minutes ago   6.48MB
librespeed-rs                latest         33a0b1a142e5   12 minutes ago   123MB
```

Also a much smaller attack surface if security's your thing