### PR TITLE
Remove unnecessary fill(0) before drop

### DIFF
--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -62,20 +62,14 @@ F: Send + Sync + Fn(Request) -> Pin<Box<dyn Future<Output = Response> + Send>>
                                     loop {
                                         let bytes_read = buf_reader.read_exact(&mut buffer).await;
                                         match bytes_read {
-                                            Ok(0) => {
-                                                buffer.fill(0);
-                                                break;
-                                            }
+                                            Ok(0) => break,
                                             Ok(_) => {
                                                 len += buffer.len();
                                                 if len >= body_size as usize {
-                                                    buffer.fill(0);
                                                     break;
                                                 }
                                             }
-                                            Err(_) => {
-                                                break;
-                                            }
+                                            Err(_) => break,
                                         }
                                     }
                                     None
@@ -90,16 +84,9 @@ F: Send + Sync + Fn(Request) -> Pin<Box<dyn Future<Output = Response> + Send>>
                             loop {
                                 let bytes_read = buf_reader.read_exact(&mut buffer).await;
                                 match bytes_read {
-                                    Ok(0) => {
-                                        buffer.fill(0);
-                                        break;
-                                    }
-                                    Ok(_) => {
-                                        buffer.fill(0);
-                                    }
-                                    Err(_) => {
-                                        break;
-                                    }
+                                    Ok(0) => break,
+                                    Ok(_) => {}
+                                    Err(_) => break,
                                 }
                             }
                             None
@@ -113,7 +100,6 @@ F: Send + Sync + Fn(Request) -> Pin<Box<dyn Future<Output = Response> + Send>>
                                             let mut body = Vec::with_capacity(body_size as usize);
                                             buf_reader.take(body_size).read_to_end(&mut body).await.unwrap();
                                             let form_data = parse_form_data(&form_boundary,&body);
-                                            body.fill(0);
                                             Some(form_data)
                                         }
                                         None => {
@@ -132,7 +118,6 @@ F: Send + Sync + Fn(Request) -> Pin<Box<dyn Future<Output = Response> + Send>>
                                     let mut body = Vec::with_capacity(body_size as usize);
                                     buf_reader.take(body_size).read_to_end(&mut body).await.unwrap();
                                     let form_data = parse_form_url_encoded(&body);
-                                    body.fill(0);
                                     Some(form_data)
                                 }
                                 None => {

--- a/src/results/telemetry.rs
+++ b/src/results/telemetry.rs
@@ -222,7 +222,6 @@ pub fn draw_result (data : &TelemetryData) -> Vec<u8> {
     if let Err(e) = img.write_to(&mut buffer, ImageFormat::Jpeg) {
         error!("Image writer buffer error : {e}")
     }
-    img.fill(0);
     drop(img);
 
     buffer.into_inner()


### PR DESCRIPTION
This is rust, it is perfectly safe to drop the memory directly, no point to `fill(0)` before:
- https://doc.rust-lang.org/stable/reference/types/array.html#r-type.array.index
> All elements of arrays are always initialized, and access to an array is always bounds-checked in safe methods and operators.
- https://doc.rust-lang.org/std/vec/struct.Vec.html#guarantees
> Do not rely on removed data to be erased for security purposes. Even if you drop a Vec, its buffer may simply be reused by another allocation. Even if you zero a Vec’s memory first, that might not actually happen because the optimizer does not consider this a side-effect that must be preserved.